### PR TITLE
Fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@
     <header>
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mdui@1.0.2/dist/css/mdui.min.css" />
       <script src="https://cdn.jsdelivr.net/npm/mdui@1.0.2/dist/js/mdui.min.js"></script>
-      <link href="https://cdn.bootcss.com/aplayer/1.10.1/APlayer.min.css" rel="stylesheet">
-      <script src="https://cdn.bootcss.com/aplayer/1.10.1/APlayer.min.js"></script>
+      <link href="https://cdn.bootcdn.net/ajax/libs/aplayer/1.10.1/APlayer.min.css" rel="stylesheet">
+      <script src="https://cdn.bootcdn.net/ajax/libs/aplayer/1.10.1/APlayer.min.js"></script>
     </header>
     <main>
       <div class="mdui-container">


### PR DESCRIPTION
```
【重要通知】：
BootCDN 对外提供服务的域名已经于两年前（即 2020 年）变更为新域名 cdn.bootcdn.net，
老域名 cdn.bootcss.com 将于 2022 年 3 月 31 日下线。
请尽快切换到新域名，以免影响贵站功能！！！

注意新文件路径中添加了 ajax/libs 字样。
例如：https://cdn.bootcss.com/jquery/3.6.0/jquery.min.js
变更为：https://cdn.bootcdn.net/ajax/libs/jquery/3.6.0/jquery.min.js
```